### PR TITLE
unset setup.cfg python-tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-python-tag = py33.py34.py35


### PR DESCRIPTION
I don't understand much about wheel compatibility tags but this caused compatibility issues in at least one case that I needed (PyPy 3.6 nightly). It was outdated anyway (it was missing 3.6 and 3.7), so I'll just strip this away. In most cases this will produce a wheel tagged `py3-none-any` which should be ok.