### PR TITLE
update to Trio 0.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         'pytest-trio >= 0.3',
     ],
     install_requires=[
-        'trio',
+        'trio >= 0.9.0',
     ],
     packages=[
         'trio_amqp',

--- a/trio_amqp/protocol.py
+++ b/trio_amqp/protocol.py
@@ -224,7 +224,7 @@ class AmqpProtocol(trio.abc.AsyncResource):
                 f = frame.get_frame(encoder)
                 try:
                     await self._stream.send_all(f)
-                except (trio.BrokenStreamError,trio.ClosedStreamError):
+                except trio.BrokenResourceError:
                     # raise exceptions.AmqpClosedConnection(self) from None
                     # the reader will raise the error also
                     return
@@ -258,7 +258,7 @@ class AmqpProtocol(trio.abc.AsyncResource):
                 encoder.write_short(0)
                 try:
                     await self._write_frame(frame, encoder)
-                except trio.ClosedStreamError:
+                except trio.BrokenResourceError:
                     pass
                 except Exception:
                     logger.exception("Error while closing")
@@ -423,7 +423,7 @@ class AmqpProtocol(trio.abc.AsyncResource):
         frame = amqp_frame.AmqpResponse(self._stream)
         try:
             await frame.read_frame()
-        except trio.BrokenStreamError:
+        except trio.BrokenResourceError:
             raise exceptions.AmqpClosedConnection(self) from None
 
         return frame
@@ -511,7 +511,7 @@ class AmqpProtocol(trio.abc.AsyncResource):
                         with trio.fail_after(timeout):
                             try:
                                 frame = await self.get_frame()
-                            except trio.ClosedStreamError:
+                            except trio.BrokenResourceError:
                                 # the stream is now *really* closed …
                                 return
                         try:

--- a/trio_amqp/protocol.py
+++ b/trio_amqp/protocol.py
@@ -224,7 +224,7 @@ class AmqpProtocol(trio.abc.AsyncResource):
                 f = frame.get_frame(encoder)
                 try:
                     await self._stream.send_all(f)
-                except trio.BrokenResourceError:
+                except (trio.BrokenResourceError, trio.ClosedResourceError):
                     # raise exceptions.AmqpClosedConnection(self) from None
                     # the reader will raise the error also
                     return
@@ -511,7 +511,7 @@ class AmqpProtocol(trio.abc.AsyncResource):
                         with trio.fail_after(timeout):
                             try:
                                 frame = await self.get_frame()
-                            except trio.BrokenResourceError:
+                            except (trio.BrokenResourceError, trio.ClosedResourceError):
                                 # the stream is now *really* closed …
                                 return
                         try:


### PR DESCRIPTION
Turns out very little is required:

- use `trio.BrokenResourceError` instead of `trio.BrokenStreamError` and `trio.ClosedStreamError` (deprecated in Trio 0.5.0)
- use `trio.open_memory_channel()` instead of `trio.Queue` (deprecated in Trio 0.9.0)
- require Trio >= 0.9.0