### PR TITLE
Fix duplicate install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,13 @@ setuptools.setup(
     setup_requires=[
         'pyrabbit',
     ],
-    install_requires=[
-        'anyio>=2',
-    ],
     keywords=['asyncio', 'amqp', 'rabbitmq', 'aio'],
     packages=[
         'async_amqp',
     ],
     install_requires=[
         'pamqp>=2.2.0,<3',
+        'anyio>=2',
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Installing package from the master branch currently breaks with `SyntaxError: keyword argument repeated: install_requires`, since there are two `install_requires` keys in `setup.py`.

This PR combines those into a single list.